### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ LABEL repository="https://github.com/r0zar/sam-deploy-action"
 LABEL homepage="https://github.com/r0zar/sam-deploy-action"
 LABEL maintainer="Ross Ragsdale <ross.ragsdale@gmail.com>"
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y awscli
 
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Action is stopping on configuring zdata step with the following interactive step. Making this change as per https://docs.docker.com/engine/reference/builder/#arg and https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai

```
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
```