### PR TITLE
v1.5 : Adds a new parameter to allow deployment of SAM templates larger than 51200 bytes over s3 bucket.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,4 +78,4 @@ output = text
 region = $AWS_REGION" > ~/.aws/config
 
 aws cloudformation package --template-file $TEMPLATE --output-template-file serverless-output.yaml --s3-bucket $AWS_DEPLOY_BUCKET $AWS_BUCKET_PREFIX $FORCE_UPLOAD $USE_JSON
-aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME $CAPABILITIES $PARAMETER_OVERRIDES $TAGS
+aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME --s3-bucket $AWS_DEPLOY_BUCKET $CAPABILITIES $PARAMETER_OVERRIDES $TAGS


### PR DESCRIPTION
Fix to deploy a template larger than 51,200 bytes with the command `aws cloudformation deploy`.

`--s3-bucket`: The URI of the Amazon S3 bucket where this command uploads your AWS CloudFormation template. This is required to deploy templates that are larger than 51,200 bytes, otherwise AWS Cloudformation gives this error for large template files.

`Templates with a size greater than 51,200 bytes must be deployed via an S3 Bucket. Please add the --s3-bucket parameter to your command. The local template will be copied to that S3 bucket and then deployed.`